### PR TITLE
fix aes cipher panic.

### DIFF
--- a/aes_cipher.go
+++ b/aes_cipher.go
@@ -24,7 +24,7 @@ func NewAESCipher(key string) *AESCipher {
 		size = 4
 	}
 	key = key[:size*8]
-	return &AESCipher{key: []byte(key), iv: []byte(key)}
+	return &AESCipher{key: []byte(key), iv: []byte(key[:16])}
 }
 
 // Decode src

--- a/aes_cipher_test.go
+++ b/aes_cipher_test.go
@@ -13,3 +13,21 @@ func TestAESCipher_Encode(t *testing.T) {
 	dencrypt := cipher.Decode(encrypt)
 	log.Debug(string(dencrypt))
 }
+
+func TestAESCipher_24key(t *testing.T) {
+	cipher := NewAESCipher("BH1rStJwNP1YIvNIffffff11")
+	painText := []byte("hello � []world ��")
+	encrypt := cipher.Encode(painText)
+	log.Debug(string(encrypt))
+	dencrypt := cipher.Decode(encrypt)
+	log.Debug(string(dencrypt))
+}
+
+func TestAESCipher_36key(t *testing.T) {
+	cipher := NewAESCipher("BH1rStJwNP1YIvNIffffff1122334455")
+	painText := []byte("hello � []world ��")
+	encrypt := cipher.Encode(painText)
+	log.Debug(string(encrypt))
+	dencrypt := cipher.Decode(encrypt)
+	log.Debug(string(dencrypt))
+}


### PR DESCRIPTION
IV length must equal block size in CBC mode, and block size is 16 in crypto/aes/cipher.go